### PR TITLE
add note about installing cython before running make

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ git clone https://github.com/cocodataset/cocoapi.git
 ```
 
 2. Setup the coco API (also described in the readme [here](https://github.com/cocodataset/cocoapi)) 
+*need to install cython first by running
+```pip install cython```
 ```
 cd cocoapi/PythonAPI  
 make  


### PR DESCRIPTION
if cython isnt installed, make will throw an error that it is unable to create cocotools